### PR TITLE
haproxy config through env

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,4 +9,8 @@ done
 
 cp -rf /opt/haproxy/error-pages /etc/haproxy/
 
-exec haproxy -f /etc/haproxy/haproxy.cfg -W -db
+if [ -z "$CONFIG" ]; then
+    CONFIG="/etc/haproxy/haproxy.cfg"
+fi
+
+exec haproxy -f $CONFIG -W -db


### PR DESCRIPTION
I'm working on the k8s charts for the Satellite GPR, and having no means to change path to the haproxy config creates troubles. Creating /etc/haproxy/haproxy.cfg as a configmap, makes /etc/haproxy dir read-only, and the entrypoint.sh can not put error pages there as result. This requires to put haproxy config outside of /etc/haproxy directory